### PR TITLE
fix: move aws-sdk to dependencies in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,13 +34,13 @@
     "lint": "eslint ."
   },
   "dependencies": {
+    "aws-sdk": "^2.226.1",
     "debug": "^3.0.0"
   },
   "peerDependencies": {
     "telegraf": "^3.9.0"
   },
   "devDependencies": {
-    "aws-sdk": "^2.226.1",
     "eslint": "^4.1.1",
     "eslint-config-standard": "^10.2.0",
     "eslint-plugin-import": "^2.2.0",


### PR DESCRIPTION
It's a runtime dependency (see [code](https://github.com/mdsina/telegraf-session-s3/blob/master/src/session.js#L2)) so I've moved it from depDepencencies to dependencies.